### PR TITLE
Update Header to Include BlackBird to track requests

### DIFF
--- a/Apps.Widn/Api/WidnClient.cs
+++ b/Apps.Widn/Api/WidnClient.cs
@@ -15,7 +15,9 @@ public class WidnClient : BlackBirdRestClient
     public WidnClient(IEnumerable<AuthenticationCredentialsProvider> authenticationCredentialsProviders) :
             base(new RestClientOptions { ThrowOnAnyError = false, BaseUrl = new Uri("https://api.widn.ai/v1") })
     {
-        this.AddDefaultHeader("x-api-key", authenticationCredentialsProviders.First(x => x.KeyName == CredsNames.ApiKey).Value);
+        this.AddDefaultHeader("x-api-key", authenticationCredentialsProviders.First(x => x.KeyName == CredsNames.ApiKey).Value);  
+        // Add the X-Widn-App header
+        this.AddDefaultHeader("X-Widn-App", CredsNames.BlackBird);
     }
 
     protected override Exception ConfigureErrorException(RestResponse response)

--- a/Apps.Widn/Apps.Widn.csproj
+++ b/Apps.Widn/Apps.Widn.csproj
@@ -6,7 +6,7 @@
         <Nullable>enable</Nullable>
         <Product>Widn</Product>
         <Description>Accurate translations, preserving meaning and nuance across +20 language pairs and various domains.</Description>
-        <Version>1.0.5</Version>
+        <Version>1.0.6</Version>
         <AssemblyName>Apps.Widn</AssemblyName>
     </PropertyGroup>
 

--- a/Apps.Widn/Constants/CredsNames.cs
+++ b/Apps.Widn/Constants/CredsNames.cs
@@ -3,4 +3,5 @@ namespace Apps.Widn.Constants;
 public static class CredsNames
 {
     public const string ApiKey = "ApiKey";
+    public const string BlackBird = "BlackBird";
 }


### PR DESCRIPTION
### PR Description

- Added the `X-Widn-App` header to `WidnClient` requests with the value `BlackBird` for tracking purposes.
- Introduced `BlackBird` constant in `CredsNames` for centralized management.
- Bumped version to `1.0.6`.